### PR TITLE
fix #2: 以 .vue 文件作为 app 入口时无法解析 config 配置

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,54 +1,59 @@
 const fs = require('fs')
-const path = require( 'path' )
+const path = require('path')
 const json5 = require('json5')
 
 const exp4parse = /\/\*[^*]*\*+(?:[^\/*][^*]*\*+)*\/|\/\/[^\r\n]*|\s/g
 
-function resolve (...args) {
-  return path.resolve( __dirname, '../', ...args)
+function resolve(...args) {
+	return path.resolve(__dirname, '../', ...args)
 }
 
-function walk4Obj (txt, startStr) {
-  if(typeof txt !== 'string' || typeof startStr !== 'string'){
-      return console.log('Props error')
-  }
-  let index = txt.indexOf(startStr),
-      resault = {},
-      begin = index + startStr.length,
-      end = begin
+function walk4Obj(txt, startStr) {
+	if (typeof txt !== 'string' || typeof startStr !== 'string') {
+		return console.log('Props error')
+	}
+	let index = txt.indexOf(startStr),
+		result = {},
+		begin = index + startStr.length,
+		end = begin
 
-  try{
-      if(index>0){
-          for(let _i = begin, _l=txt.length, _a=0;_i<_l;_i++) {
-              switch(txt.charAt(_i) || '') {
-                  case '{': _a ++
-                  break
-                  case '}': _a --
-                  break
-                  default : break
-              }
-              if(_a <= 0) {
-                  end = _i
-                  break
-              }
-          }
-          resault = json5.parse(txt.substring(begin,end+1))
-      }
-
-  } catch (e) {
-      console.log(e)
-  }
-  return resault
+	try {
+		if (index > 0) {
+			for (let _i = begin, _l = txt.length, _a = 0; _i < _l; _i++) {
+				switch (txt.charAt(_i) || '') {
+					case '{':
+						_a++
+						break
+					case '}':
+						_a--
+						break
+					default:
+						break
+				}
+				if (_a <= 0) {
+					end = _i
+					break
+				}
+			}
+			result = json5.parse(txt.substring(begin, end + 1))
+		}
+	} catch (e) {
+		console.log(e)
+	}
+	return result
 }
 
-function getAppObj(file){
-    let txt = fs.readFileSync(file,'utf8')
-    txt = txt.replace(exp4parse,'')
-    return walk4Obj(txt,'exportdefault')['config'] || {}
+function getAppObj(file) {
+	let txt = fs.readFileSync(file, 'utf8')
+	txt = txt.replace(exp4parse, '')
+	if (file.substring(file.length - 4) === '.vue') {
+		return walk4Obj(txt, 'config>')
+	}
+	return walk4Obj(txt, 'exportdefault')['config'] || {}
 }
 
 module.exports = {
-  resolve,
-  walk4Obj,
-  getAppObj
+	resolve,
+	walk4Obj,
+	getAppObj
 }


### PR DESCRIPTION
抱歉，vscode 配置导致大部分修改为缩进，看起来有点乱。
核心只增加了以下三行代码
```javascript
function getAppObj(file) {
	let txt = fs.readFileSync(file, 'utf8')
	txt = txt.replace(exp4parse, '')
+	if (file.substring(file.length - 4) === '.vue') {
+		return walk4Obj(txt, 'config>')
+	}
	return walk4Obj(txt, 'exportdefault')['config'] || {}
}
```
问题详见：#2 